### PR TITLE
Pinecone methods and LangChain OpenAI Embeddings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Ignore .env file
 .env
+.venv
 
 # Ignore Python virtual environment
 venv/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Ignore .env file
+.env
+
+# Ignore Python virtual environment
+venv/
+__pycache__/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python: AWSLambda",
+      "type": "python",
+      "request": "launch",
+      "module": "lambda_function.lambda_handler",
+      "cwd": "${workspaceFolder}/AWSLambda"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.black-formatter"
+  },
+  "python.formatting.provider": "none",
+  "cmake.configureOnOpen": false
+}

--- a/AWSLambda/embeddings_utils.py
+++ b/AWSLambda/embeddings_utils.py
@@ -1,0 +1,23 @@
+import os
+from langchain.embeddings import OpenAIEmbeddings
+from dotenv import load_dotenv
+
+
+# Load environment variables from .env
+load_dotenv()
+
+openai_api_key = os.getenv("OPENAI_API_KEY")
+embeddings = OpenAIEmbeddings(openai_api_key=openai_api_key)
+
+# Here two methods that use Open AI embeddings model to generate
+# embeddings for documents (i.e. texts) and for user query
+
+
+def get_docs_embeddings(docs):
+    doc_result = embeddings.embed_documents(docs)
+    return doc_result
+
+
+def get_query_embedding(query):
+    query_result = embeddings.embed_query(query)
+    return query_result

--- a/AWSLambda/lambda_function.py
+++ b/AWSLambda/lambda_function.py
@@ -5,12 +5,6 @@ def lambda_handler(event, context):
     try:
         main()
 
-        return {
-            'statusCode': 200,
-            'body': 'Lambda function executed successfully!'
-        }
+        return {"statusCode": 200, "body": "Lambda function executed successfully!"}
     except Exception as e:
-        return {
-            'statusCode': 500,
-            'body': str(e)
-        }
+        return {"statusCode": 500, "body": str(e)}

--- a/AWSLambda/main.py
+++ b/AWSLambda/main.py
@@ -5,15 +5,19 @@ from code_fetcher import fetch_script_text
 from pinecone_utils import insert_vectors
 from vectorizer import get_embedding_vector
 
+from dotenv import load_dotenv
+
+# Load environment variables from .env
+load_dotenv()
+
+
 pinecone_key = os.getenv("PINECONE_KEY")
 pinecone_env = os.getenv("PINECONE_ENV")
 
+
 INDEX_NAME = "indexvectornauts1"
 
-pc.init(
-    api_key=pinecone_key,
-    environment=pinecone_env
-)
+pc.init(api_key=pinecone_key, environment=pinecone_env)
 
 code_example = "def max(a,b): if a>b: return a else return b"
 url_test = "https://raw.githubusercontent.com/devmaxime/codextranauts/AWSLambda/AWSLambda/vectorizer.py"
@@ -37,5 +41,5 @@ def main():
     insert_vectors(index, [vector_id], [embedding_vector])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/AWSLambda/main.py
+++ b/AWSLambda/main.py
@@ -1,11 +1,12 @@
 import os
 import pinecone as pc
-
 from code_fetcher import fetch_script_text
-from pinecone_utils import insert_vectors
-from vectorizer import get_embedding_vector
-
+from pinecone_utils import upsert_vectors
 from dotenv import load_dotenv
+
+# from embeddings_utils import docs_embeddings, query_embedding
+# from vectorizer import get_embedding_vector
+
 
 # Load environment variables from .env
 load_dotenv()
@@ -15,7 +16,7 @@ pinecone_key = os.getenv("PINECONE_KEY")
 pinecone_env = os.getenv("PINECONE_ENV")
 
 
-INDEX_NAME = "indexvectornauts1"
+INDEX_NAME = "test-pinecone-index"  # "indexvectornauts1"
 
 pc.init(api_key=pinecone_key, environment=pinecone_env)
 
@@ -28,7 +29,9 @@ def main():
 
     code_test_text = fetch_script_text(url_test)
 
-    embedding_vector = get_embedding_vector(code_test_text)
+    upsert_vectors(index=index, texts=[code_test_text])
+
+    # embedding_vector = get_embedding_vector(code_test_text)
 
     # Flatten the embedding tensor
     # embedding_flat = embedding_vector.view(-1, embedding_vector.size(-1))
@@ -36,9 +39,9 @@ def main():
     # Convert the embedding tensor to a NumPy array
     # embedding_np = embedding_flat.detach().numpy().tolist()
 
-    vector_id = "A"
+    # vector_id = "A"
 
-    insert_vectors(index, [vector_id], [embedding_vector])
+    # upsert_vectors(index, [vector_id], [embedding_vector])
 
 
 if __name__ == "__main__":

--- a/AWSLambda/pinecone_utils.py
+++ b/AWSLambda/pinecone_utils.py
@@ -1,3 +1,49 @@
-def insert_vectors(index, ids, vectors):
-    upsert_response = index.upsert(ids=ids, vectors=vectors)
-    print(upsert_response)
+import os
+import pinecone as pc
+from embeddings_utils import get_query_embedding, get_docs_embeddings
+
+
+pinecone_key = os.getenv("PINECONE_KEY")
+pinecone_env = os.getenv("PINECONE_ENV")
+
+
+index_name = "test-pinecone-index"  # "indexvectornauts1"
+pc.init(api_key=pinecone_key, environment=pinecone_env)
+index = pc.Index(index_name=index_name)
+
+
+def create_index(index_name, dimension=1536):
+    # check if exists and, if yes, delete the index
+    # if index_name in pc.list_indexes():
+    #     pc.delete_index(index_name)
+
+    # check if doesn't exist and, if doesn't, create the index
+    if index_name not in pc.list_indexes():
+        pc.create_index(
+            name=index_name,
+            dimension=dimension,
+            metric="cosine",
+        )
+
+
+def upsert_vectors(index, texts):
+    # TODO: how to handle ids?
+    # TODO: what metadata to include?
+    vectors = []
+    for i, text in enumerate(texts, start=1):
+        vectors.append((str(i), get_docs_embeddings(text)[0], {"text": text}))
+
+    index.upsert(vectors)
+
+
+def query_index(index, query, k=3, filter={}):
+    vector = get_query_embedding(query)
+
+    result_vectors = index.query(
+        vector=vector,
+        # include_values=True,
+        include_metadata=True,
+        top_k=k,
+        filter=filter,
+    )
+    return result_vectors

--- a/AWSLambda/requirements.txt
+++ b/AWSLambda/requirements.txt
@@ -2,3 +2,4 @@ requests
 astunparse
 transformers
 pinecone-client
+langchain

--- a/AWSLambda/requirements.txt
+++ b/AWSLambda/requirements.txt
@@ -1,0 +1,4 @@
+requests
+astunparse
+transformers
+pinecone-client

--- a/AWSLambda/vectorizer.py
+++ b/AWSLambda/vectorizer.py
@@ -21,8 +21,9 @@ def get_tokens_ids(tokens):
 #     context_embeddings = model.encode(text)
 #     return context_embeddings
 
+
 def get_embedding_vector(text):
-    feature_extractor = pipeline('feature-extraction', model=model, tokenizer=tokenizer)
+    feature_extractor = pipeline("feature-extraction", model=model, tokenizer=tokenizer)
 
     # Generate the embeddings
     embeddings = feature_extractor(text)

--- a/event.json
+++ b/event.json
@@ -1,0 +1,3 @@
+{
+  "git_url": "https://raw.githubusercontent.com/devmaxime/codextranauts/AWSLambda/AWSLambda/vectorizer.py"
+}


### PR DESCRIPTION
* Used out-of-the-box embeddings offered by LangChain: https://python.langchain.com/docs/modules/data_connection/text_embedding/integrations/openai
* NOTE: because the dimensionality of OpenAI vectors if **1536** and BERT's is **768**, I had to create a separate Pinecone index for testing (you will need API keys for that if you want to test, so let me know). Once we make a call as to which embedding model to use, I will update the team's pinecone index accordingly.